### PR TITLE
Refactored socketTest to Main + VelocidroneClient

### DIFF
--- a/VelocidroneClient.js
+++ b/VelocidroneClient.js
@@ -1,0 +1,44 @@
+'use strict';
+
+import { readFile } from 'fs/promises';
+import WebSocket from 'ws';
+
+var VelocidroneClient = {
+    ws: {},
+    settings: {},
+
+    initialise: async (settingsPath, messageCallback, openCallback, closeCallback, errorCallback) => {
+        VelocidroneClient.settings = JSON.parse((await readFile(settingsPath)).toString());
+
+        VelocidroneClient.ws = new WebSocket(`ws://${VelocidroneClient.settings.localIP}:60003/velocidrone`);
+
+        VelocidroneClient.ws.on('error', console.error);
+        if (errorCallback !== undefined) {
+            VelocidroneClient.ws.on('error', errorCallback);
+        }
+
+        VelocidroneClient.ws.on('open', function open() {
+            VelocidroneClient.heartBeat();
+            console.log("connected");
+        });
+        if (openCallback !== undefined){
+            VelocidroneClient.ws.on('open', openCallback);
+        }
+
+        VelocidroneClient.ws.on("close", function finished(code, reason) {
+            console.log("closed: %s", reason)
+        })
+        if (closeCallback !== undefined){
+            VelocidroneClient.ws.on("close", closeCallback);
+        }
+
+        VelocidroneClient.ws.on('message', messageCallback);
+    },
+
+    heartBeat: () => {
+        VelocidroneClient.ws.send("");
+        setTimeout(VelocidroneClient.heartBeat, 10000);
+    }
+}
+
+export default VelocidroneClient;

--- a/main.js
+++ b/main.js
@@ -1,0 +1,58 @@
+import VelocidroneClient  from "./VelocidroneClient.js";
+
+var heatData = [];
+
+function createPilot (pilotData) {
+    return {"name": pilotName,
+            "holeshot": pilotData.time,
+            "laps": [pilotData.time],
+            "lap": pilotData.lap,
+            "finished": pilotData.finished};
+  }
+
+function message (data) {
+    console.log('received: %s', data);
+
+    if (data.length == 0) return;
+
+    var raceData = JSON.parse(data);
+
+    if (raceData["racestatus"] != null) {
+        if (raceData["racestatus"]["raceAction"] == "start") {
+            console.log("start new race");
+            heatData = [];
+        }
+    }
+    else if (raceData["racedata"] != null) {
+        for (let pilotName of Object.keys(raceData["racedata"])) {
+            let pilotData = raceData["racedata"][pilotName];
+            var pilot = heatData.find(e => e.name == pilotName);
+
+            if (pilot == null) {
+                var pilot = createPilot(pilotData);
+                heatData.push(pilot);
+                console.log(`Holeshot ${pilotName} ${pilot.holeshot}`);
+            } else {
+                if (pilot.lap != pilotData.lap) {
+                    pilot.laps.push(pilotData.time);
+                    pilot.lap = pilotData.lap;
+                    const lapLength = pilot.laps.length;
+                    const lapTime = pilot.laps[lapLength - 1] - pilot.laps[lapLength - 2];
+                    console.log(`Lap ${pilotName} ${lapTime}`);
+                }
+
+                if (pilot.finished != pilotData.finished) {
+                    pilot.finished = pilotData.finished;
+                    pilot.laps.push(pilotData.time);
+                    pilot.lap = pilotData.lap;
+                    const lapLength = pilot.laps.length;
+                    const lapTime = pilot.laps[lapLength - 1] - pilot.laps[lapLength - 2];
+                    console.log(`Lap ${pilotName} ${lapTime}`);
+                    console.log(`${pilotName} finished in ${pilotData.time}`);
+                }
+            }
+        }
+    }
+}
+
+await VelocidroneClient.initialise("settings.json", message);


### PR DESCRIPTION
Mr.E pointed me to this, very excited by ws and Velocidrone.

A simple refactor that's just creating a VelocidroneClient.js out of the existing socketTest.js.

Message consumption implementation split in to main.js as the example use of the client.

Will happily accept criticisms and suggestions, it's been a while since I've done any JS and am also use to completing User Stories where the architecture has been fleshed out, or at least am in contact with the other devs working on the same thing where we can al agree on things.

I do have further thoughts on this but they are around using the client in a proxy way where it just forwards the traffic over http for purposes of google sheets or a web app.