### PR TITLE
Added pilot tracking such that only new pilot data gets sent out

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -1,5 +1,4 @@
-import VelocidroneClient  from "./VelocidroneClient.js";
-import * as http from 'http'
+import VelocidroneClient from "./VelocidroneClient.js";
 
 import fs from "node:fs";
 
@@ -9,79 +8,118 @@ const RACEACTIONKEYNAME = 'raceaction';
 
 var raceStarted = false;
 
-async function message(data){
-    var jsonString = data.toString();
-    
-    if (jsonString.length == 0) return
+var pilotDictionary = {};
 
-    var obj = JSON.parse(jsonString);
+async function message(data) {
+	var jsonString = data.toString();
 
-    var endpoint = null;
+	if (jsonString.length == 0 || jsonString[0] !== '{') return
 
-    if (obj[RACEDATAKEYNAME] != null && raceStarted == true) {
-        endpoint = '/racedata';
-    }
-    else if (obj[RACESTATUSKEYNAME] != null) {
-        endpoint = '/racestatus';
+	var obj = JSON.parse(jsonString);
 
-        if(obj.racestatus.raceAction == 'start') {
-            raceStarted = true;
-        }
-        else if(obj.racestatus.raceAction =='abort' || obj.racestatus.raceAction == 'race finished') {
-            raceStarted = false;
-        }
-    }
+	var endpoint = null;
 
-    if (endpoint){
-        await postMessage(endpoint, JSON.stringify(obj));
-    }
+	if (obj[RACEDATAKEYNAME] != null && shouldSend(obj[RACEDATAKEYNAME])) {
+		obj = buildRaceDataForSending(obj);
+		endpoint = '/racedata';
+	}
+	else if (obj[RACESTATUSKEYNAME] != null) {
+		endpoint = '/racestatus';
+
+		if (obj.racestatus.raceAction == 'start') {
+			raceStarted = true;
+			pilotDictionary = {};
+		}
+		else if (obj.racestatus.raceAction == 'abort' || obj.racestatus.raceAction == 'race finished') {
+			raceStarted = false;
+		}
+	}
+
+	if (endpoint) {
+		await postMessage(endpoint, JSON.stringify(obj));
+	}
 }
 
-async function postMessage (url, data) {
-   
-    try {
-        var res = await fetch('http://127.0.0.1:3000' + url, {
-            method: 'POST',
-            body: data,
-            headers: {
-                'Content-Type': 'application/json',
-                'x-api-key': '{USERAPIKEY}'
-            }
-        });
-    } catch(error) {
-        console.log(error);
-    }
+function buildRaceDataForSending(data) {
+	let returnObj = {};
+	returnObj[RACEDATAKEYNAME] = {};
+
+	for (let pilotName of Object.keys(data[RACEDATAKEYNAME])) {
+		let pilotData = data[RACEDATAKEYNAME][pilotName];
+
+		let shouldSend = shouldSendForPilot(pilotData);
+
+		if (shouldSend == true && pilotDictionaryHasPilot(pilotName) == false) {
+			pilotDictionary[pilotName] = createPilot(pilotData, pilotName);
+			returnObj[RACEDATAKEYNAME][pilotName] = data[RACEDATAKEYNAME][pilotName];
+		}
+		else if (shouldSend == true) {
+			pilotDictionary[pilotName].times.push(pilotData.time);
+			returnObj[RACEDATAKEYNAME][pilotName] = data[RACEDATAKEYNAME][pilotName];
+		}
+	}
+
+	return returnObj;
+}
+
+function shouldSend(data) {
+	if (raceStarted == false) {
+		return false;
+	}
+
+	for (let pilotName of Object.keys(data)) {
+		let pilotData = data[pilotName];
+
+		return shouldSendForPilot(pilotData, pilotName);
+	}
+}
+
+function shouldSendForPilot(pilotData, pilotName) {
+	var pilot = getPilotFromDictionary(pilotName);
+
+	return pilot == null || pilot.times[pilot.times.length - 1] != pilotData.time;
+}
+
+function getPilotFromDictionary(pilotName) {
+	return pilotDictionaryHasPilot(pilotName) == true ? pilotDictionary[pilotName] : null;
+}
+
+function pilotDictionaryHasPilot(pilotName) {
+	return pilotDictionary.hasOwnProperty(pilotName) == true;
+}
+
+function createPilot(pilotData, pilotName) {
+	return {
+		"name": pilotName,
+		"times": [pilotData.time]
+	};
+}
+
+async function postMessage(url, data) {
+
+	try {
+		var res = await fetch('http://127.0.0.1:3000' + url, {
+			method: 'POST',
+			body: data,
+			headers: {
+				'Content-Type': 'application/json',
+				'x-api-key': '{USERAPIKEY}'
+			}
+		});
+	} catch (error) {
+		console.log(error);
+	}
 }
 
 await VelocidroneClient.initialise("settings.json", message);
 
 //await VelocidroneClient.initialise("settings.json", (data) => {console.log(data.toString());});
 
-// fs.readFile("./VelocidroneWebApp/crashvelocidronetest.txt",  "utf8", async (err, d) => {
-//     let dataRows = d.split(/\r?\n/);
-//     for (let row in dataRows)
-//     {
-//         var json = dataRows[row].toString();
-        
-//         if (json.length == 0) return
+// fs.readFile(".\\V1data-test.txt", "utf16le", async (err, d) => {
+// 	if (d === undefined) { return; }
+// 	let dataRows = d.split(/\r?\n/);
 
-//         var data = JSON.parse(json);
-
-//         var endpoint = null;
-
-//         if (data[RACEDATAKEYNAME] != null) {
-//             endpoint = '/racedata';
-//         }
-//         else if (data[RACESTATUSKEYNAME] != null) {
-//             endpoint = '/racestatus';
-//         }
-//         else if (data["racetype"] != null) {
-//             endpoint = '/racetype';
-//         }
-
-//         if (endpoint){
-//             await postMessage(endpoint, JSON.stringify(data));
-//         }
-//     }
-
+// 	for (let row in dataRows) {
+// 		message(dataRows[row].toString());
+// 	}
 // });


### PR DESCRIPTION
Adds pilots to global dictionary if they don't exist in it already.
If it either doesn't exist or the time given the pilot is different, add the time/pilot

Builds a new obj from the data that has changed and sends that instead of the data straight out of Velocidrone.

When a new race starts (I.E. we get a "start" status from Velocidrone), reset the pilotDictionary.